### PR TITLE
Fix Bug at  llc-test-harness-AI123-AO56

### DIFF
--- a/scripts/llc-test-harness-AI123-AO56
+++ b/scripts/llc-test-harness-AI123-AO56
@@ -16,9 +16,16 @@ SC=0
 CA=13
 CB=12
 
+FUNCLIST="init_comms init_2106 start_stream cleanup user_prompt"
 
 # MUST set remote ip-address
-REMIP=${1:-${REMIP:-acq2106_003}}       # use arg1 if set, else env, else default. Users might want to just set the default locally
+if [[ ! ${FUNCLIST} =~ ${!#} ]] && [ $# != 0 ]; then
+    REMIP=${!#:-${REMIP:-acq2106_003}}
+    set -- "${@:1:$#-1}"
+else
+    REMIP=${REMIP:-acq2106_003}     
+fi
+
 USER_PROMPT=${USER_PROMPT:-y}		# y forces break between init and run
 INTCLKDIV=${INTCLKDIV:-10000}		# 100M/100 = 100kHz
 EXTCLKDIV=${EXTCLKDIV:-10}		# 1M/10 = 100kHz
@@ -173,7 +180,7 @@ if [ "x$*" = "x" ]; then
 	[ "$USER_PROMPT" = "y" ] && user_prompt
 	start_stream
 else
-	for arg in $*; do
+	for arg in $@; do
 		echo RUN $arg
 		eval $arg
 	done

--- a/scripts/llc-test-harness-AI123-AO56
+++ b/scripts/llc-test-harness-AI123-AO56
@@ -18,7 +18,7 @@ CB=12
 
 
 # MUST set remote ip-address
-REMIP=${1:-acq2106_003}
+REMIP=${REMIP:-acq2106_003}
 USER_PROMPT=${USER_PROMPT:-y}		# y forces break between init and run
 INTCLKDIV=${INTCLKDIV:-10000}		# 100M/100 = 100kHz
 EXTCLKDIV=${EXTCLKDIV:-10}		# 1M/10 = 100kHz

--- a/scripts/llc-test-harness-AI123-AO56
+++ b/scripts/llc-test-harness-AI123-AO56
@@ -34,12 +34,12 @@ TRANSIENT=${TRANSIENT:-2000000}
 
 
 AISITES=${AISITES:-1,2,3}
-# pick off the first AI site as M
+# pick off the last AI site as M
 AI=${AISITES%,*}
 
 
 AOSITES=${AOSITES:-5,6}
-# pick off the first AO site as M.
+# pick off the last AO site as M.
 AO=${AOSITES%,*}
 
 # DO assume ALL OUTPUTS. 

--- a/scripts/llc-test-harness-AI123-AO56
+++ b/scripts/llc-test-harness-AI123-AO56
@@ -35,6 +35,7 @@ LLC_CLK=${LLC_CLK:-ext}
 # next run the CONTROL PROGRAM
 # THEN trigger (eg ext trigger, or run soft_trigger command on box
 SOFT_TRIGGER=${SOFT_TRIGGER:-0}
+LLC_TRG=${LLC_TRG:-ext}
 
 # default transient mode, set # samples.  "no": run continuous mode
 TRANSIENT=${TRANSIENT:-2000000}


### PR DESCRIPTION
$1 occupied $REMIP causing `nc: getaddrinfo: Temporary failure in name resolution` when running with arguments.