### PR TITLE
Add mount-tmpfs-ramdisk

### DIFF
--- a/scripts/mount-tmpfs-ramdisk
+++ b/scripts/mount-tmpfs-ramdisk
@@ -6,4 +6,4 @@
 
 SIZE=${1:-8G}
 
-mount -o size=$SIZE -t tmpfs none /mnt
+mount -o size=$SIZE -t tmpfs ramdisk /mnt

--- a/scripts/mount-tmpfs-ramdisk
+++ b/scripts/mount-tmpfs-ramdisk
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Mount a tmpfs ramdisk of a specified size (e.g. `8G` for 8 GiB) at /mnt. Requires sudo.
+# The benefit compared to a normal ramdisk is that it cannot expand indefinitely and is
+# less likely to crash the system by using up all RAM
+
+SIZE=${1:-8G}
+
+mount -o size=$SIZE -t tmpfs none /mnt


### PR DESCRIPTION
* Mount tmpfs ramdisk with size limit, default to 8 GiB
* Helps prevent using up all RAM during acquisition and crashing the system