### PR TITLE
PDE_DATA() replaced by pde_data() in 5.17

### DIFF
--- a/acq-fiber-hba.h
+++ b/acq-fiber-hba.h
@@ -49,7 +49,7 @@
 #include "gpumemdrv.h"
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,14,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0)
 #define PDE_DATA(in)	pde_data(in)
 #endif
 


### PR DESCRIPTION
c.f. https://github.com/openzfs/zfs/issues/13004

currently does not work on ubuntu-20 kernel 5.15.0
