### PR TITLE
Remove usage of exit in RTM_T_Device; clenaup class and rtm-t-stream

### DIFF
--- a/STREAM/RTM_T_Device.cpp
+++ b/STREAM/RTM_T_Device.cpp
@@ -9,109 +9,122 @@
  *  @brief interface to RTM_T Device (historic name for AFHBA404)
  */
 
-#include <stdio.h>
-#include <unistd.h>
-#include <errno.h>
+#include <cerrno>
+#include <cstring>
+#include <fcntl.h>
+#include <stdexcept>
 #include <stdlib.h>
 #include <sys/mman.h>
-#include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/time.h>
-#include <fcntl.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include "local.h"
 #include "RTM_T_Device.h"
-
-
-
+#include "local.h"
 
 static unsigned calc_nbuffers(unsigned devnum);
 static unsigned calc_maxlen(unsigned devnum);
 static unsigned calc_transfer_buffers(unsigned devnum);
 
-RTM_T_Device::RTM_T_Device(int _devnum) :
-	devnum(_devnum%100), nbuffers(calc_nbuffers(devnum)),
-	maxlen(calc_maxlen(devnum)),
-	transfer_buffers(calc_transfer_buffers(devnum))
-{
-	char buf[120];
+void throw_os_error(const std::string &hint, int err) {
+	errno = err;
+	throw std::runtime_error(hint);
+}
 
-	sprintf(buf, "/dev/rtm-t.%d", devnum);
-	names[MINOR_DMAREAD] = buf;
-	_open(MINOR_DMAREAD);
+int RTM_T_Device::_open(const char *name, int mode) {
+	const int fp = open(name, mode);
+	if (fp == -1) {
+		const int err = errno;
+		_close();
+		throw_os_error(std::string("open ") + name, err);
+	}
+	return fp;
+}
 
-	sprintf(buf, "/dev/rtm-t.%d.regs", devnum);
-	names[MINOR_REGREAD] = buf;
-	_open(MINOR_REGREAD);
+inline void RTM_T_Device::_close() {
+	for (const auto buffer : host_buffers) {
+		munmap(buffer, maxlen);
+	}
+	if (dmaread_fd != -1)
+		close(dmaread_fd);
+	if (regread_fd != -1)
+		close(regread_fd);
+}
 
-	for (int ib = 0; ib < nbuffers; ++ib){
-		sprintf(buf, "/dev/rtm-t.%d.data/hb%02d", devnum, ib);
-		names[ib] = buf;
+RTM_T_Device::~RTM_T_Device() { _close(); }
+RTM_T_Device::RTM_T_Device(int _devnum)
+    : devnum(_devnum % 100), nbuffers(calc_nbuffers(devnum)),
+      maxlen(calc_maxlen(devnum)),
+      transfer_buffers(calc_transfer_buffers(devnum)) {
+	char name[128];
 
-		_open(ib);
-		void *va = mmap(0, maxlen, PROT_READ|PROT_WRITE,
-				MAP_SHARED, handles[ib], 0);
+	sprintf(name, "/dev/rtm-t.%u.ctrl", devnum);
+	name_ctlroot = name;
 
-		if (va == (caddr_t)-1 ){
-			perror( "mmap" );
-		        _exit(errno);
-		}else{
-			host_buffers[ib] = va;
+	sprintf(name, "/dev/rtm-t.%u", devnum);
+	name_dmaread = name;
+	dmaread_fd = _open(name);
+
+	sprintf(name, "/dev/rtm-t.%u.regs", devnum);
+	name_regread = name;
+	regread_fd = _open(name);
+    host_buffers.reserve(nbuffers);
+	for (int ib = 0; ib < nbuffers; ++ib) {
+		sprintf(name, "/dev/rtm-t.%u.data/hb%04d", devnum, ib);
+		const int fd = _open(name);
+		void *const va =
+		    mmap(0, maxlen, PROT_READ, MAP_SHARED, fd, 0);
+		close(fd);
+		if (va == (void *)-1) {
+			const int err = errno;
+			_close();
+			throw_os_error(std::string("mmap ") + name, err);
+		} else {
+			host_buffers.push_back(va);
 		}
 	}
-
-	sprintf(buf, "/dev/rtm-t.%d.ctrl", devnum);
-	names[CTRL_ROOT] = buf;
 }
 
-static int getKnob(const char* knob, unsigned* value)
-{
-        FILE *fp = fopen(knob, "r");
-	if (!fp)
-	{
-		perror(knob);
+static int getKnob(const char *knob, unsigned *value) {
+	FILE *const fp = fopen(knob, "r");
+	if (!fp) {
 		return -1;
 	}
-        int rc = fscanf(fp, "%u", value);
-        fclose(fp);
-        return rc;
+	const int rc = fscanf(fp, "%u", value);
+	fclose(fp);
+	return rc;
 }
 
-#define PARAMETERS              "/sys/module/afhba/parameters/"
-#define BUFFER_LEN              PARAMETERS "buffer_len"
-#define NBUFFERS                PARAMETERS "nbuffers"
-#define TRANSFER_BUFFERS        PARAMETERS "transfer_buffers"
+#define PARAMETERS "/sys/module/afhba/parameters/"
+#define BUFFER_LEN PARAMETERS "buffer_len"
+#define NBUFFERS PARAMETERS "nbuffers"
+#define TRANSFER_BUFFERS PARAMETERS "transfer_buffers"
 
-static unsigned calc_transfer_buffers(unsigned devnum)
-{
+static unsigned calc_transfer_buffers(unsigned devnum) {
 	unsigned transfer_buffers = 0;
-	if (getKnob(TRANSFER_BUFFERS, &transfer_buffers) != 1){
-		perror("getKnob " TRANSFER_BUFFERS " failed");
-		exit(1);
+	if (getKnob(TRANSFER_BUFFERS, &transfer_buffers) != 1) {
+		throw std::runtime_error("getKnob " TRANSFER_BUFFERS " failed");
 	}
 	return transfer_buffers;
 }
 
-static unsigned calc_nbuffers(unsigned devnum)
-{
+static unsigned calc_nbuffers(unsigned devnum) {
 	unsigned nbuffers = 0;
-	if (getKnob(NBUFFERS, &nbuffers) != 1){
-		perror("getKnob " NBUFFERS " failed");
-		exit(1);
+	if (getKnob(NBUFFERS, &nbuffers) != 1) {
+		throw std::runtime_error("getKnob " NBUFFERS " failed");
 	}
 	return nbuffers;
 }
-static unsigned calc_maxlen(unsigned devnum)
-{
-        char knob[80];
-	unsigned maxlen;
+static unsigned calc_maxlen(unsigned devnum) {
+	unsigned buffer_len = 0;
+	char knob[80];
 	snprintf(knob, 80, "/dev/rtm-t.%u.ctrl/buffer_len", devnum);
-	if (getKnob(knob, &maxlen) == 1){
-		return maxlen;
-	}else if (getKnob(BUFFER_LEN, &maxlen) == 1){
-		return maxlen;
-        }else{
-		perror("maxlen not set");
-		exit(1);
+	if (getKnob(knob, &buffer_len) == 1) {
+		return buffer_len;
+	} else if (getKnob(BUFFER_LEN, &buffer_len) == 1) {
+		return buffer_len;
+	} else {
+		throw std::runtime_error("buffer_len not set");
 	}
 }

--- a/STREAM/RTM_T_Device.cpp
+++ b/STREAM/RTM_T_Device.cpp
@@ -28,28 +28,28 @@ static unsigned calc_maxlen(unsigned devnum);
 static unsigned calc_transfer_buffers(unsigned devnum);
 
 void throw_os_error(const std::string &hint, int err) {
-	errno = err;
-	throw std::runtime_error(hint);
+  errno = err;
+  throw std::runtime_error(hint);
 }
 
 int RTM_T_Device::_open(const char *name, int mode) {
-	const int fp = open(name, mode);
-	if (fp == -1) {
-		const int err = errno;
-		_close();
-		throw_os_error(std::string("open ") + name, err);
-	}
-	return fp;
+  const int fp = open(name, mode);
+  if (fp == -1) {
+    const int err = errno;
+    _close();
+    throw_os_error(std::string("open ") + name, err);
+  }
+  return fp;
 }
 
 inline void RTM_T_Device::_close() {
-	for (const auto buffer : host_buffers) {
-		munmap(buffer, maxlen);
-	}
-	if (dmaread_fd != -1)
-		close(dmaread_fd);
-	if (regread_fd != -1)
-		close(regread_fd);
+  for (const auto buffer : host_buffers) {
+    munmap(buffer, maxlen);
+  }
+  if (dmaread_fd != -1)
+    close(dmaread_fd);
+  if (regread_fd != -1)
+    close(regread_fd);
 }
 
 RTM_T_Device::~RTM_T_Device() { _close(); }
@@ -57,43 +57,42 @@ RTM_T_Device::RTM_T_Device(int _devnum)
     : devnum(_devnum % 100), nbuffers(calc_nbuffers(devnum)),
       maxlen(calc_maxlen(devnum)),
       transfer_buffers(calc_transfer_buffers(devnum)) {
-	char name[128];
+  char name[128];
 
-	sprintf(name, "/dev/rtm-t.%u.ctrl", devnum);
-	name_ctlroot = name;
+  sprintf(name, "/dev/rtm-t.%u.ctrl", devnum);
+  name_ctlroot = name;
 
-	sprintf(name, "/dev/rtm-t.%u", devnum);
-	name_dmaread = name;
-	dmaread_fd = _open(name);
+  sprintf(name, "/dev/rtm-t.%u", devnum);
+  name_dmaread = name;
+  dmaread_fd = _open(name);
 
-	sprintf(name, "/dev/rtm-t.%u.regs", devnum);
-	name_regread = name;
-	regread_fd = _open(name);
-    host_buffers.reserve(nbuffers);
-	for (int ib = 0; ib < nbuffers; ++ib) {
-		sprintf(name, "/dev/rtm-t.%u.data/hb%04d", devnum, ib);
-		const int fd = _open(name);
-		void *const va =
-		    mmap(0, maxlen, PROT_READ, MAP_SHARED, fd, 0);
-		close(fd);
-		if (va == (void *)-1) {
-			const int err = errno;
-			_close();
-			throw_os_error(std::string("mmap ") + name, err);
-		} else {
-			host_buffers.push_back(va);
-		}
-	}
+  sprintf(name, "/dev/rtm-t.%u.regs", devnum);
+  name_regread = name;
+  regread_fd = _open(name);
+  host_buffers.reserve(nbuffers);
+  for (int ib = 0; ib < nbuffers; ++ib) {
+    sprintf(name, "/dev/rtm-t.%u.data/hb%04d", devnum, ib);
+    const int fd = _open(name);
+    void *const va = mmap(0, maxlen, PROT_READ, MAP_SHARED, fd, 0);
+    close(fd);
+    if (va == (void *)-1) {
+      const int err = errno;
+      _close();
+      throw_os_error(std::string("mmap ") + name, err);
+    } else {
+      host_buffers.push_back(va);
+    }
+  }
 }
 
 static int getKnob(const char *knob, unsigned *value) {
-	FILE *const fp = fopen(knob, "r");
-	if (!fp) {
-		return -1;
-	}
-	const int rc = fscanf(fp, "%u", value);
-	fclose(fp);
-	return rc;
+  FILE *const fp = fopen(knob, "r");
+  if (!fp) {
+    return -1;
+  }
+  const int rc = fscanf(fp, "%u", value);
+  fclose(fp);
+  return rc;
 }
 
 #define PARAMETERS "/sys/module/afhba/parameters/"
@@ -102,29 +101,29 @@ static int getKnob(const char *knob, unsigned *value) {
 #define TRANSFER_BUFFERS PARAMETERS "transfer_buffers"
 
 static unsigned calc_transfer_buffers(unsigned devnum) {
-	unsigned transfer_buffers = 0;
-	if (getKnob(TRANSFER_BUFFERS, &transfer_buffers) != 1) {
-		throw std::runtime_error("getKnob " TRANSFER_BUFFERS " failed");
-	}
-	return transfer_buffers;
+  unsigned transfer_buffers = 0;
+  if (getKnob(TRANSFER_BUFFERS, &transfer_buffers) != 1) {
+    throw std::runtime_error("getKnob " TRANSFER_BUFFERS " failed");
+  }
+  return transfer_buffers;
 }
 
 static unsigned calc_nbuffers(unsigned devnum) {
-	unsigned nbuffers = 0;
-	if (getKnob(NBUFFERS, &nbuffers) != 1) {
-		throw std::runtime_error("getKnob " NBUFFERS " failed");
-	}
-	return nbuffers;
+  unsigned nbuffers = 0;
+  if (getKnob(NBUFFERS, &nbuffers) != 1) {
+    throw std::runtime_error("getKnob " NBUFFERS " failed");
+  }
+  return nbuffers;
 }
 static unsigned calc_maxlen(unsigned devnum) {
-	unsigned buffer_len = 0;
-	char knob[80];
-	snprintf(knob, 80, "/dev/rtm-t.%u.ctrl/buffer_len", devnum);
-	if (getKnob(knob, &buffer_len) == 1) {
-		return buffer_len;
-	} else if (getKnob(BUFFER_LEN, &buffer_len) == 1) {
-		return buffer_len;
-	} else {
-		throw std::runtime_error("buffer_len not set");
-	}
+  unsigned buffer_len = 0;
+  char knob[80];
+  snprintf(knob, 80, "/dev/rtm-t.%u.ctrl/buffer_len", devnum);
+  if (getKnob(knob, &buffer_len) == 1) {
+    return buffer_len;
+  } else if (getKnob(BUFFER_LEN, &buffer_len) == 1) {
+    return buffer_len;
+  } else {
+    throw std::runtime_error("buffer_len not set");
+  }
 }

--- a/STREAM/RTM_T_Device.h
+++ b/STREAM/RTM_T_Device.h
@@ -19,36 +19,34 @@
 #include <unistd.h>
 
 class RTM_T_Device {
-	std::string name_ctlroot;
-	std::string name_dmaread;
-	std::string name_regread;
-	std::vector<void *> host_buffers;
-	int dmaread_fd = -1;
-	int regread_fd = -1;
+  std::string name_ctlroot;
+  std::string name_dmaread;
+  std::string name_regread;
+  std::vector<void *> host_buffers;
+  int dmaread_fd = -1;
+  int regread_fd = -1;
 
-	inline int _open(const char *name, int mode = O_RDONLY);
-	inline void _close(void);
+  inline int _open(const char *name, int mode = O_RDONLY);
+  inline void _close(void);
 
-  public:
-	static constexpr int MAXBUF = 32; // maximum buffers per read
-	const unsigned devnum;
-	const unsigned nbuffers;
-	const unsigned maxlen;
-	const unsigned transfer_buffers;
+public:
+  static constexpr int MAXBUF = 32; // maximum buffers per read
+  const unsigned devnum;
+  const unsigned nbuffers;
+  const unsigned maxlen;
+  const unsigned transfer_buffers;
 
-	RTM_T_Device(int _devnum);
-	virtual ~RTM_T_Device();
-	const char *getDevice(void) { return name_dmaread.c_str(); }
-	const int getDeviceHandle(void) { return dmaread_fd; }
-	const char *getRegsDevice(void) { return name_regread.c_str(); }
-	const void *getHostBufferMapping(int ibuf = 0) {
-		return host_buffers[ibuf];
-	}
-	void *getHostBufferMappingW(int ibuf = 0) { return host_buffers[ibuf]; }
+  RTM_T_Device(int _devnum);
+  virtual ~RTM_T_Device();
+  const char *getDevice(void) { return name_dmaread.c_str(); }
+  const int getDeviceHandle(void) { return dmaread_fd; }
+  const char *getRegsDevice(void) { return name_regread.c_str(); }
+  const void *getHostBufferMapping(int ibuf = 0) { return host_buffers[ibuf]; }
+  void *getHostBufferMappingW(int ibuf = 0) { return host_buffers[ibuf]; }
 
-	const char *getControlRoot(void) { return name_ctlroot.c_str(); }
-	int getDevnum(void) const { return devnum; }
-	int next(int ibuf) { return ++ibuf == nbuffers ? 0 : ibuf; }
+  const char *getControlRoot(void) { return name_ctlroot.c_str(); }
+  int getDevnum(void) const { return devnum; }
+  int next(int ibuf) { return ++ibuf == nbuffers ? 0 : ibuf; }
 };
 
 #endif /* RTM_T_DEVICE_H_ */

--- a/STREAM/rtm-t-stream.cpp
+++ b/STREAM/rtm-t-stream.cpp
@@ -18,40 +18,39 @@
     Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.                */
 /* ------------------------------------------------------------------------- */
 
-
 /** @file rtm-t-stream.cpp
  *  @brief D-TACQ PCIe RTM_T stream access solib
  * Continuous streaming using PCIe and buffers
  * */
 
-#include <stdio.h>
-#include <unistd.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <sys/eventfd.h>
 #include <sys/ioctl.h>
-#include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/time.h>
-#include <fcntl.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include "local.h"
-#include "rtm-t_ioctl.h"
 #include "RTM_T_Device.h"
-
+#include "local.h"
 #include "rtm-t-stream.h"
+#include "rtm-t_ioctl.h"
 
-#define DBG(args...)	//fprintf(stderr, args)
+#define DBG(args...) // fprintf(stderr, args)
 
 #ifdef __GNUC__
-#define LIKELY(x)      (__builtin_expect(!!(x), 1))
-#define UNLIKELY(x)    (__builtin_expect(!!(x), 0))
+#define LIKELY(x) (__builtin_expect(!!(x), 1))
+#define UNLIKELY(x) (__builtin_expect(!!(x), 0))
 #else
-#define LIKELY(x)       (x)
-#define UNLIKELY(x)     (x)
+#define LIKELY(x) (x)
+#define UNLIKELY(x) (x)
 #endif
 
-#define SBDN		RTM_T_Device::MAXBUF
+#define SBDN RTM_T_Device::MAXBUF
 typedef struct {
 	RTM_T_Device *dev;
 	int stop;
@@ -60,144 +59,131 @@ typedef struct {
 	struct StreamBufferDef sbd[SBDN];
 } STREAM, *STREAM_P;
 
+#define TEST_NULLPTR(ptr)                                                      \
+	do {                                                                       \
+		if UNLIKELY (!ptr) {                                                   \
+			fprintf(stderr, "NULL pointer error\n");                           \
+			return -1;                                                         \
+		}                                                                      \
+	} while (0)
+#define ERROR_START(errorcode, message)                                        \
+	do {                                                                       \
+		perror(message);                                                       \
+		if (stream && stream->dev)                                             \
+			delete stream->dev;                                                \
+		if (stream)                                                            \
+			free(stream);                                                      \
+		return errorcode;                                                      \
+	} while (0)
 
-#define TEST_NULLPTR(ptr) do{if UNLIKELY(!ptr){fprintf(stderr, "NULL pointer error");return -1;}}while(0)
-#define ERROR_START(errorcode, message) do{\
-	perror(message " error");\
-	if (stream && stream->dev)\
-		delete stream->dev;\
-	if (stream)\
-		free(stream);\
-	return errorcode;\
-}while(0)
-
-#include <poll.h>
-#define CHECK(i)	(pfds[i].revents & POLLIN)
-#define CHECK_STOP	CHECK(0)
-#define CHECK_FD	CHECK(1)
-static int fetch_buffers(STREAM_P const stream)
-{
+#define CHECK(i) (pfds[i].revents & POLLIN)
+#define CHECK_STOP CHECK(0)
+#define CHECK_FD CHECK(1)
+static int fetch_buffers(STREAM_P const stream) {
 	stream->ibuf = 0;
 	const int fd = stream->dev->getDeviceHandle();
 	struct pollfd pfds[2] = {
-		{ .fd=stream->stop, .events=POLLIN },
-		{ .fd=fd,           .events=POLLIN },
+	    {.fd = stream->stop, .events = POLLIN},
+	    {.fd = fd, .events = POLLIN},
 	};
 	const int ready = poll(pfds, 2, -1);
-	if LIKELY(ready > 0)
-	{
-		if LIKELY(!CHECK_STOP && CHECK_FD)
-		{
-			const int nread = read(fd, stream->sbd, SBDN*SBDSZ);
+	if LIKELY (ready > 0) {
+		if LIKELY (!CHECK_STOP && CHECK_FD) {
+			const int nread = read(fd, stream->sbd, SBDN * SBDSZ);
 			DBG("nread=%d\n", nread);
-			if UNLIKELY(nread < 0)
-			{
-		                perror("read error");
-		                return -1;
-			}
-			else
-			{
-		                stream->nbuf = nread/SBDSZ;
+			if UNLIKELY (nread < 0) {
+				perror("read error");
+				return -1;
+			} else {
+				stream->nbuf = nread / SBDSZ;
 				return 0;
-		        }
-		}
-		else
-		{
+			}
+		} else {
 			stream->nbuf = 0;
 			return 0; // end if stream
 		}
-	}
-	else if (ready < -1)
-	{
+	} else if (ready < -1) {
 		perror("poll error");
 		return -1;
-	}
-	else
-	{
+	} else {
 		stream->nbuf = 0;
 		return 0; // timeout == -1 so end if stream ?
 	}
 }
 
-static inline int get_bufno(StreamBufferDef* sbd)
-{
-	if UNLIKELY((sbd->ibuf&IBUF_MAGIC_MASK) != IBUF_MAGIC)
-	{
-		fprintf(stderr, "ERROR NOT IBUF_MAGIC %08x %08x\n",
-				sbd->ibuf, sbd->esta);
-		exit(1);
+static inline int get_bufno(StreamBufferDef *sbd) {
+	if UNLIKELY ((sbd->ibuf & IBUF_MAGIC_MASK) != IBUF_MAGIC) {
+		fprintf(stderr, "ERROR NOT IBUF_MAGIC %08x %08x\n", sbd->ibuf,
+		        sbd->esta);
+		return -1;
 	}
-	return sbd->ibuf&IBUF_IBUF;
+	return sbd->ibuf & IBUF_IBUF;
 }
 
-static inline int release_buffer(void *const handle, const int bufno)
-{
-	return write(((STREAM_P)handle)->dev->getDeviceHandle(), &bufno, sizeof(int)) != sizeof(int);
+static inline int release_buffer(void *const handle, const int bufno) {
+	return write(((STREAM_P)handle)->dev->getDeviceHandle(), &bufno,
+	             sizeof(int)) != sizeof(int);
 }
 
-EXPORT int RtmStreamStart(void **handle, const int devnum, const int NBUFS, int *const maxlen)
-{
+EXPORT int RtmStreamStart(void **handle, const int devnum, const int NBUFS,
+                          int *const maxlen) {
 	TEST_NULLPTR(handle);
-	STREAM_P const stream = (STREAM_P)malloc(sizeof(STREAM));
-	if UNLIKELY(!stream)
-		ERROR_START(1, "malloc");
-	if UNLIKELY((stream->stop = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK)) < 0)
-		ERROR_START(2, "eventfd");
-	RTM_T_Device *dev = stream->dev = new RTM_T_Device(devnum);
-	if UNLIKELY(!dev)
-		ERROR_START(3, "RTM_T_Device");
-	const int fp = dev->getDeviceHandle();
-	const int rc = NBUFS
-		? ioctl(fp, RTM_T_START_STREAM_MAX, &NBUFS)
-		: ioctl(fp, RTM_T_START_STREAM);
-	if UNLIKELY(rc)
-		ERROR_START(4, "ioctl");
+	STREAM_P const stream = (STREAM_P)calloc(1, sizeof(STREAM));
+	if UNLIKELY (!stream)
+		ERROR_START(1, "malloc failed");
+	if UNLIKELY ((stream->stop = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK)) < 0)
+		ERROR_START(2, "eventfd failed");
+	try {
+		stream->dev = new RTM_T_Device(devnum);
+	} catch (const std::exception &e) {
+		ERROR_START(3, e.what());
+	}
+	const int fp = stream->dev->getDeviceHandle();
+	const int rc = NBUFS ? ioctl(fp, RTM_T_START_STREAM_MAX, &NBUFS)
+	                     : ioctl(fp, RTM_T_START_STREAM);
+	if UNLIKELY (rc)
+		ERROR_START(4, "ioctl failed");
 	stream->nbuf = 0;
 	stream->ibuf = 0;
 	if (maxlen)
-		*maxlen = dev->maxlen;
-	*handle = (void*)stream;
+		*maxlen = stream->dev->maxlen;
+	*handle = (void *)stream;
 	return 0;
 }
 
-EXPORT int RtmStreamStop(void *handle)
-{
+EXPORT int RtmStreamStop(void *handle) {
 	TEST_NULLPTR(handle);
 	STREAM_P const stream = (STREAM_P)handle;
 	const uint64_t value = 1;
 	return write(stream->stop, &value, sizeof(value)) != sizeof(value);
 }
 
-
-EXPORT int RtmStreamClose(void *handle)
-{
-        TEST_NULLPTR(handle);
-        STREAM_P const stream = (STREAM_P)handle;
+EXPORT int RtmStreamClose(void *handle) {
+	TEST_NULLPTR(handle);
+	STREAM_P const stream = (STREAM_P)handle;
 	delete stream->dev;
 	close(stream->stop);
 	free(handle);
 	return 0;
 }
 
-EXPORT int RtmStreamGetBuffer(void *handle, void *const buf, const int buflen)
-{
+EXPORT int RtmStreamGetBuffer(void *handle, void *const buf, const int buflen) {
 	TEST_NULLPTR(handle);
 	TEST_NULLPTR(buf);
 	STREAM_P const stream = (STREAM_P)handle;
-	if (stream->ibuf == stream->nbuf)
-	{
+	if (stream->ibuf == stream->nbuf) {
 		DBG("update ibuf=%d nbuf=%d\n", stream->ibuf, stream->nbuf);
-		if (fetch_buffers(stream))
-		{
+		if (fetch_buffers(stream)) {
 			perror("fetch error");
 			return -1;
 		}
-		if UNLIKELY(!stream->nbuf)
-		{
+		if UNLIKELY (!stream->nbuf) {
 			return 1;
 		}
 	}
 	const int bufno = get_bufno(&stream->sbd[stream->ibuf++]);
+	if (bufno == -1)
+		return -1;
 	DBG("ibuf=%d nbuf=%d bufno=%d\n", stream->ibuf, stream->nbuf, bufno);
 	memcpy(buf, stream->dev->getHostBufferMapping(bufno), buflen);
 	return release_buffer(stream, bufno);

--- a/STREAM/rtm-t-stream.cpp
+++ b/STREAM/rtm-t-stream.cpp
@@ -52,139 +52,138 @@
 
 #define SBDN RTM_T_Device::MAXBUF
 typedef struct {
-	RTM_T_Device *dev;
-	int stop;
-	int nbuf;
-	int ibuf;
-	struct StreamBufferDef sbd[SBDN];
+  RTM_T_Device *dev;
+  int stop;
+  int nbuf;
+  int ibuf;
+  struct StreamBufferDef sbd[SBDN];
 } STREAM, *STREAM_P;
 
 #define TEST_NULLPTR(ptr)                                                      \
-	do {                                                                       \
-		if UNLIKELY (!ptr) {                                                   \
-			fprintf(stderr, "NULL pointer error\n");                           \
-			return -1;                                                         \
-		}                                                                      \
-	} while (0)
+  do {                                                                         \
+    if UNLIKELY (!ptr) {                                                       \
+      fprintf(stderr, "NULL pointer error\n");                                 \
+      return -1;                                                               \
+    }                                                                          \
+  } while (0)
 #define ERROR_START(errorcode, message)                                        \
-	do {                                                                       \
-		perror(message);                                                       \
-		if (stream && stream->dev)                                             \
-			delete stream->dev;                                                \
-		if (stream)                                                            \
-			free(stream);                                                      \
-		return errorcode;                                                      \
-	} while (0)
+  do {                                                                         \
+    perror(message);                                                           \
+    if (stream && stream->dev)                                                 \
+      delete stream->dev;                                                      \
+    if (stream)                                                                \
+      free(stream);                                                            \
+    return errorcode;                                                          \
+  } while (0)
 
 #define CHECK(i) (pfds[i].revents & POLLIN)
 #define CHECK_STOP CHECK(0)
 #define CHECK_FD CHECK(1)
 static int fetch_buffers(STREAM_P const stream) {
-	stream->ibuf = 0;
-	const int fd = stream->dev->getDeviceHandle();
-	struct pollfd pfds[2] = {
-	    {.fd = stream->stop, .events = POLLIN},
-	    {.fd = fd, .events = POLLIN},
-	};
-	const int ready = poll(pfds, 2, -1);
-	if LIKELY (ready > 0) {
-		if LIKELY (!CHECK_STOP && CHECK_FD) {
-			const int nread = read(fd, stream->sbd, SBDN * SBDSZ);
-			DBG("nread=%d\n", nread);
-			if UNLIKELY (nread < 0) {
-				perror("read error");
-				return -1;
-			} else {
-				stream->nbuf = nread / SBDSZ;
-				return 0;
-			}
-		} else {
-			stream->nbuf = 0;
-			return 0; // end if stream
-		}
-	} else if (ready < -1) {
-		perror("poll error");
-		return -1;
-	} else {
-		stream->nbuf = 0;
-		return 0; // timeout == -1 so end if stream ?
-	}
+  stream->ibuf = 0;
+  const int fd = stream->dev->getDeviceHandle();
+  struct pollfd pfds[2] = {
+      {.fd = stream->stop, .events = POLLIN},
+      {.fd = fd, .events = POLLIN},
+  };
+  const int ready = poll(pfds, 2, -1);
+  if LIKELY (ready > 0) {
+    if LIKELY (!CHECK_STOP && CHECK_FD) {
+      const int nread = read(fd, stream->sbd, SBDN * SBDSZ);
+      DBG("nread=%d\n", nread);
+      if UNLIKELY (nread < 0) {
+        perror("read error");
+        return -1;
+      } else {
+        stream->nbuf = nread / SBDSZ;
+        return 0;
+      }
+    } else {
+      stream->nbuf = 0;
+      return 0; // end if stream
+    }
+  } else if (ready < -1) {
+    perror("poll error");
+    return -1;
+  } else {
+    stream->nbuf = 0;
+    return 0; // timeout == -1 so end if stream ?
+  }
 }
 
 static inline int get_bufno(StreamBufferDef *sbd) {
-	if UNLIKELY ((sbd->ibuf & IBUF_MAGIC_MASK) != IBUF_MAGIC) {
-		fprintf(stderr, "ERROR NOT IBUF_MAGIC %08x %08x\n", sbd->ibuf,
-		        sbd->esta);
-		return -1;
-	}
-	return sbd->ibuf & IBUF_IBUF;
+  if UNLIKELY ((sbd->ibuf & IBUF_MAGIC_MASK) != IBUF_MAGIC) {
+    fprintf(stderr, "ERROR NOT IBUF_MAGIC %08x %08x\n", sbd->ibuf, sbd->esta);
+    return -1;
+  }
+  return sbd->ibuf & IBUF_IBUF;
 }
 
 static inline int release_buffer(void *const handle, const int bufno) {
-	return write(((STREAM_P)handle)->dev->getDeviceHandle(), &bufno,
-	             sizeof(int)) != sizeof(int);
+  return write(((STREAM_P)handle)->dev->getDeviceHandle(), &bufno,
+               sizeof(int)) != sizeof(int);
 }
 
 EXPORT int RtmStreamStart(void **handle, const int devnum, const int NBUFS,
                           int *const maxlen) {
-	TEST_NULLPTR(handle);
-	STREAM_P const stream = (STREAM_P)calloc(1, sizeof(STREAM));
-	if UNLIKELY (!stream)
-		ERROR_START(1, "malloc failed");
-	if UNLIKELY ((stream->stop = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK)) < 0)
-		ERROR_START(2, "eventfd failed");
-	try {
-		stream->dev = new RTM_T_Device(devnum);
-	} catch (const std::exception &e) {
-		ERROR_START(3, e.what());
-	}
-	const int fp = stream->dev->getDeviceHandle();
-	const int rc = NBUFS ? ioctl(fp, RTM_T_START_STREAM_MAX, &NBUFS)
-	                     : ioctl(fp, RTM_T_START_STREAM);
-	if UNLIKELY (rc)
-		ERROR_START(4, "ioctl failed");
-	stream->nbuf = 0;
-	stream->ibuf = 0;
-	if (maxlen)
-		*maxlen = stream->dev->maxlen;
-	*handle = (void *)stream;
-	return 0;
+  TEST_NULLPTR(handle);
+  STREAM_P const stream = (STREAM_P)calloc(1, sizeof(STREAM));
+  if UNLIKELY (!stream)
+    ERROR_START(1, "malloc failed");
+  if UNLIKELY ((stream->stop = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK)) < 0)
+    ERROR_START(2, "eventfd failed");
+  try {
+    stream->dev = new RTM_T_Device(devnum);
+  } catch (const std::exception &e) {
+    ERROR_START(3, e.what());
+  }
+  const int fp = stream->dev->getDeviceHandle();
+  const int rc = NBUFS ? ioctl(fp, RTM_T_START_STREAM_MAX, &NBUFS)
+                       : ioctl(fp, RTM_T_START_STREAM);
+  if UNLIKELY (rc)
+    ERROR_START(4, "ioctl failed");
+  stream->nbuf = 0;
+  stream->ibuf = 0;
+  if (maxlen)
+    *maxlen = stream->dev->maxlen;
+  *handle = (void *)stream;
+  return 0;
 }
 
 EXPORT int RtmStreamStop(void *handle) {
-	TEST_NULLPTR(handle);
-	STREAM_P const stream = (STREAM_P)handle;
-	const uint64_t value = 1;
-	return write(stream->stop, &value, sizeof(value)) != sizeof(value);
+  TEST_NULLPTR(handle);
+  STREAM_P const stream = (STREAM_P)handle;
+  const uint64_t value = 1;
+  return write(stream->stop, &value, sizeof(value)) != sizeof(value);
 }
 
 EXPORT int RtmStreamClose(void *handle) {
-	TEST_NULLPTR(handle);
-	STREAM_P const stream = (STREAM_P)handle;
-	delete stream->dev;
-	close(stream->stop);
-	free(handle);
-	return 0;
+  TEST_NULLPTR(handle);
+  STREAM_P const stream = (STREAM_P)handle;
+  delete stream->dev;
+  close(stream->stop);
+  free(handle);
+  return 0;
 }
 
 EXPORT int RtmStreamGetBuffer(void *handle, void *const buf, const int buflen) {
-	TEST_NULLPTR(handle);
-	TEST_NULLPTR(buf);
-	STREAM_P const stream = (STREAM_P)handle;
-	if (stream->ibuf == stream->nbuf) {
-		DBG("update ibuf=%d nbuf=%d\n", stream->ibuf, stream->nbuf);
-		if (fetch_buffers(stream)) {
-			perror("fetch error");
-			return -1;
-		}
-		if UNLIKELY (!stream->nbuf) {
-			return 1;
-		}
-	}
-	const int bufno = get_bufno(&stream->sbd[stream->ibuf++]);
-	if (bufno == -1)
-		return -1;
-	DBG("ibuf=%d nbuf=%d bufno=%d\n", stream->ibuf, stream->nbuf, bufno);
-	memcpy(buf, stream->dev->getHostBufferMapping(bufno), buflen);
-	return release_buffer(stream, bufno);
+  TEST_NULLPTR(handle);
+  TEST_NULLPTR(buf);
+  STREAM_P const stream = (STREAM_P)handle;
+  if (stream->ibuf == stream->nbuf) {
+    DBG("update ibuf=%d nbuf=%d\n", stream->ibuf, stream->nbuf);
+    if (fetch_buffers(stream)) {
+      perror("fetch error");
+      return -1;
+    }
+    if UNLIKELY (!stream->nbuf) {
+      return 1;
+    }
+  }
+  const int bufno = get_bufno(&stream->sbd[stream->ibuf++]);
+  if (bufno == -1)
+    return -1;
+  DBG("ibuf=%d nbuf=%d bufno=%d\n", stream->ibuf, stream->nbuf, bufno);
+  memcpy(buf, stream->dev->getHostBufferMapping(bufno), buflen);
+  return release_buffer(stream, bufno);
 }


### PR DESCRIPTION
When used as library exiting with exit() would terminate the calling process. we want to properly pass on errors for handling.

includes #119