### PR TITLE
Fix stream lib streaming

### DIFF
--- a/STREAM_LIB/RTM_T_Device.cpp
+++ b/STREAM_LIB/RTM_T_Device.cpp
@@ -64,14 +64,14 @@ RTM_T_Device::RTM_T_Device(int _devnum)
 
   sprintf(name, "/dev/rtm-t.%u", devnum);
   name_dmaread = name;
-  dmaread_fd = _open(name);
+  dmaread_fd = _open(name, O_RDWR);
 
   sprintf(name, "/dev/rtm-t.%u.regs", devnum);
   name_regread = name;
   regread_fd = _open(name);
   host_buffers.reserve(nbuffers);
   for (int ib = 0; ib < nbuffers; ++ib) {
-    sprintf(name, "/dev/rtm-t.%u.data/hb%04d", devnum, ib);
+    sprintf(name, "/dev/rtm-t.%u.data/hb%02d", devnum, ib);
     const int fd = _open(name);
     void *const va = mmap(0, maxlen, PROT_READ, MAP_SHARED, fd, 0);
     close(fd);

--- a/STREAM_LIB/RTM_T_Device.cpp
+++ b/STREAM_LIB/RTM_T_Device.cpp
@@ -64,7 +64,7 @@ RTM_T_Device::RTM_T_Device(int _devnum)
 
   sprintf(name, "/dev/rtm-t.%u", devnum);
   name_dmaread = name;
-  dmaread_fd = _open(name, O_RDWR);
+  dmaread_fd = _open(name);
 
   sprintf(name, "/dev/rtm-t.%u.regs", devnum);
   name_regread = name;


### PR DESCRIPTION
 match hb%02d node naming.  the host-buffer nodes were opened as hb%04d while the driver creates hb%02d (as in STREAM/ and LLCONTROL/), so open() failed with ENOENT.